### PR TITLE
gatk installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,5 @@ RUN conda install bwa=0.7.15
 
 # Install PLINK2
 RUN conda install -c bioconda plink2
+
+USER $NB_UID

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,21 @@
-FROM ucsdets/scipy-ml-notebook
+FROM ucsdets/scipy-ml-notebook:2019.4.6
 
 USER root
 
 # Install GATK
-FROM broadinstitute/gatk:4.1.4.1
+#FROM broadinstitute/gatk:4.1.4.1
+
+RUN pwd && \
+    apt-get update && \
+    apt-get install --yes default-jdk && \
+    cd /opt && \
+    wget -q https://github.com/broadinstitute/gatk/releases/download/4.1.4.1/gatk-4.1.4.1.zip && \
+    unzip -q gatk-4.1.4.1.zip && \
+    ln -s /opt/gatk-4.1.4.1/gatk /usr/bin/gatk && \
+    rm gatk-4.1.4.1.zip && \
+    cd /opt/gatk-4.1.4.1 && \
+    ls -al  && \
+    cd /home/jovyan
 
 # Install PLINK2
 RUN conda install --quiet --yes -c bioconda plink2


### PR DESCRIPTION
I added a RUN statement to install Java and download gatk to /opt/gatk-version.

It's not possible to use a second FROM statement for the gatk docker container because it overwrites the ucsd-ets/sci-py-ml container which is needed for our installation.